### PR TITLE
Adding Guard NPM

### DIFF
--- a/lib/hesburgh_infrastructure/guard.rb
+++ b/lib/hesburgh_infrastructure/guard.rb
@@ -36,6 +36,11 @@ module HesburghInfrastructure
       end
     end
 
+    def npm(options ={})
+      guard 'npm' do
+        watch('package.json')
+      end
+    end
     def rails(options = {})
       options = {
         port: application.rails_port,


### PR DESCRIPTION
Adding guard-npm plugin configuration so we don't have to manually remember to run `npm install` when new node modules are added.

@jonhartzler 
@jaronkk